### PR TITLE
Updated the package to make it compatible with julia v1.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ julia:
   - 1.1
   - 1.0
   - nightly
-  - release
 notifications:
   email: false
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'if VERSION >= v"0.7.0-" using Pkg; end; Pkg.clone(pwd()); Pkg.build("PiecewiseIncreasingRanges"); Pkg.test("PiecewiseIncreasingRanges"; coverage=true)'
+  - julia --color=yes -e 'using Pkg; Pkg.build()'
+  - julia --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test(coverage=true)'
 after_success:
-  - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'if VERSION >= v"0.7.0-" using Pkg; end; import PiecewiseIncreasingRanges; cd(joinpath(dirname(pathof(PiecewiseIncreasingRanges)),"..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi
+  - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'using Pkg; import PiecewiseIncreasingRanges; cd(joinpath(dirname(pathof(PiecewiseIncreasingRanges)),"..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: julia
 os:
   - linux
 julia:
-  - release
+  - 1.1
+  - 1.0
   - nightly
+  - release
 notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("PiecewiseIncreasingRanges"); Pkg.test("PiecewiseIncreasingRanges"; coverage=true)'
+  - julia --check-bounds=yes -e 'if VERSION >= v"0.7.0-" using Pkg; end; Pkg.clone(pwd()); Pkg.build("PiecewiseIncreasingRanges"); Pkg.test("PiecewiseIncreasingRanges"; coverage=true)'
 after_success:
-  - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'cd(Pkg.dir("PiecewiseIncreasingRanges")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi
+  - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'if VERSION >= v"0.7.0-" using Pkg; end; import PiecewiseIncreasingRanges; cd(joinpath(dirname(pathof(PiecewiseIncreasingRanges)),"..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PiecewiseIncreasingRanges"
 uuid = "efdf428f-f294-58b6-a961-90c8051bff4c"
-version = "0.0.5"
+version = "0.1.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,16 @@
+name = "PiecewiseIncreasingRanges"
+uuid = "efdf428f-f294-58b6-a961-90c8051bff4c"
+version = "0.0.5"
+
+[deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+
+[compat]
+julia = "≥ 1.0"
+
+[extras]
+Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Interpolations"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 1.1.1
-Compat

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
+julia 1.1.1
 Compat

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,1 @@
-Grid
+Interpolations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using PiecewiseIncreasingRanges, Base.Test, Grid
+using PiecewiseIncreasingRanges, Test, Interpolations
 
 function test(rgs, divisor...)
     vcrgs = vcat(rgs...)
@@ -7,11 +7,11 @@ function test(rgs, divisor...)
     @test length(rg.ranges) == 4
     @test vcrgs == rg
 
-    yi = InterpGrid(convert(Vector{Float64}, vcrgs), BCnil, InterpLinear)
-    @test_approx_eq resample(rg, 3//7) yi[1:7//3:length(yi)]
-    @test_approx_eq resample(rg, 7//3) yi[1:3//7:length(yi)]
-    @test_approx_eq resample(rg, 5//9) yi[1:9//5:length(yi)]
-    @test_approx_eq resample(rg, 61//3) yi[1:3//61:length(yi)]
+    yi = LinearInterpolation(1:length(vcrgs),convert(Vector{Float64}, vcrgs))
+    @test resample(rg, 3//7) ≈ yi(1:7//3:length(yi))
+    @test resample(rg, 7//3) ≈ yi(1:3//7:length(yi))
+    @test resample(rg, 5//9) ≈ yi(1:9//5:length(yi))
+    @test resample(rg, 61//3) ≈ yi(1:3//61:length(yi))
 
     for i = 1:length(rg)
         @test searchsortedfirst(rg, rg[i]) == i
@@ -49,7 +49,7 @@ end
 
 test(StepRange{Int,Int}[0:4:40, 41:1:80, 82:2:112, 114:2:120, 136:4:144], 8)
 test(StepRange{Rational{Int},Rational{Int}}[0:1//2:5, 5+1//8:1//8:10, 10+1//4:1//4:14, 14+1//4:1//4:15, 17:1//2:18])
-test(FloatRange{Float64}[0:1//2:5., 5+1//8:1//8:10., 10+1//4:1//4:14., 14+1//4:1//4:15., 17:1//2:18.])
+test(StepRangeLen{Float64}[0:1//2:5., 5+1//8:1//8:10., 10+1//4:1//4:14., 14+1//4:1//4:15., 17:1//2:18.])
 
 # Empty test
 rg = PiecewiseIncreasingRange(StepRange{Rational{Int},Rational{Int}}[])
@@ -63,9 +63,9 @@ rg = PiecewiseIncreasingRange(UnitRange{Int}[0:-1])
 @test_throws ArgumentError PiecewiseIncreasingRange(StepRange{Rational{Int},Rational{Int}}[0:1//2:1, 3//4:1//2:4])
 @test_throws ArgumentError PiecewiseIncreasingRange(StepRange{Rational{Int},Rational{Int}}[0:-1//2:-1, 10:1//2:8])
 @test_throws ArgumentError PiecewiseIncreasingRange(StepRange{Rational{Int},Rational{Int}}[0:1//2:1, 10:-1//2:8])
-@test_throws ArgumentError PiecewiseIncreasingRange(FloatRange{Float64}[0:0.5:1, 0.75:0.5:4])
-@test_throws ArgumentError PiecewiseIncreasingRange(FloatRange{Float64}[0:-0.5:-1, 10:0.5:8])
-@test_throws ArgumentError PiecewiseIncreasingRange(FloatRange{Float64}[0:0.5:1, 10:-0.5:8])
+@test_throws ArgumentError PiecewiseIncreasingRange(StepRangeLen{Float64}[0:0.5:1, 0.75:0.5:4])
+@test_throws ArgumentError PiecewiseIncreasingRange(StepRangeLen{Float64}[0:-0.5:-1, 10:0.5:8])
+@test_throws ArgumentError PiecewiseIncreasingRange(StepRangeLen{Float64}[0:0.5:1, 10:-0.5:8])
 
 # Test with empty ranges interspersed with non-empty ranges
 rg = PiecewiseIncreasingRange(UnitRange{Int}[0:-1, 1:0, 0:-1, 1:3, 0:-1, 5:10])


### PR DESCRIPTION
Julia v1 defines parametric types differently from previous versions. I have updated the definitions to make it compatible with the latest version. Since this is not a backward compatible step I have updated the REQUIRE file to reflect this. Tests now require Interpolations.jl instead of Grid.jl as the latter is incompatible with recent julia versions.